### PR TITLE
리팩토링: AuditingFields 클래스를 추상 클래스로 변경

### DIFF
--- a/board/src/main/java/com/fc/board/domain/Article.java
+++ b/board/src/main/java/com/fc/board/domain/Article.java
@@ -3,14 +3,8 @@ package com.fc.board.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/board/src/main/java/com/fc/board/domain/ArticleComment.java
+++ b/board/src/main/java/com/fc/board/domain/ArticleComment.java
@@ -4,13 +4,7 @@ import javax.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter

--- a/board/src/main/java/com/fc/board/domain/AuditingFields.java
+++ b/board/src/main/java/com/fc/board/domain/AuditingFields.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class AuditingFields {
+public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)

--- a/board/src/test/java/com/fc/board/repository/JpaRepositoryTest.java
+++ b/board/src/test/java/com/fc/board/repository/JpaRepositoryTest.java
@@ -5,10 +5,8 @@ import com.fc.board.domain.Article;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 


### PR DESCRIPTION
엔티티에서 상속을 해서 사용해야 하는 목적에 더 잘 맞게 abstract 키워드 추가
별도 이슈 없이 작업함