### PR TITLE
헤로쿠에 배포하기 - DB변경 (ClearDB -> JawsDB)

### DIFF
--- a/board/src/main/resources/application.yaml
+++ b/board/src/main/resources/application.yaml
@@ -31,6 +31,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
조사해본 결과, cleardb의 기본 mysql버전이 `5.6`으로 너무 낮기 때문에 대안으로 jawsDB를 찾아냄. 
`5.6` 버전에서 `article_comment.content`인덱스 사이즈가 너무 큼.
기본 mysql 버전 `8.0` -> 이를 이용해 환경 변수를 다시 작업!

This closes #55 