### PR TITLE
[리팩토링] deprecated된 댓글 업데이트 기능 삭제

### DIFF
--- a/board/src/main/java/com/fc/board/service/ArticleCommentService.java
+++ b/board/src/main/java/com/fc/board/service/ArticleCommentService.java
@@ -1,7 +1,6 @@
 package com.fc.board.service;
 
 import com.fc.board.domain.Article;
-import com.fc.board.domain.ArticleComment;
 import com.fc.board.domain.UserAccount;
 import com.fc.board.dto.ArticleCommentDto;
 import com.fc.board.repository.ArticleCommentRepository;
@@ -39,21 +38,6 @@ public class ArticleCommentService {
             articleCommentRepository.save(dto.toEntity(article, userAccount));
         } catch (EntityNotFoundException e) {
             log.warn("댓글 저장 실패. 댓글 작성에 필요한 정보를 찾을 수 없습니다 - dto: {}", e.getLocalizedMessage());
-        }
-    }
-
-    /**
-     * @deprecated 댓글 수정 기능은 클라이언트에서 생각할 점이 많아지기 떄문에, 이번 개발에서는 제공하지 않기로 했다.
-     */
-    @Deprecated
-    public void updateArticleComment(ArticleCommentDto dto) {
-        try {
-            ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
-            if (dto.content() != null) {
-                articleComment.setContent(dto.content());
-            }
-        } catch (EntityNotFoundException e) {
-            log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다 - dto: {}", dto);
         }
     }
 

--- a/board/src/test/java/com/fc/board/service/ArticleCommentServiceTest.java
+++ b/board/src/test/java/com/fc/board/service/ArticleCommentServiceTest.java
@@ -87,40 +87,6 @@ class ArticleCommentServiceTest {
         then(articleCommentRepository).shouldHaveNoInteractions();
     }
 
-    @DisplayName("댓글 정보를 입력하면, 댓글을 수정한다.")
-    @Test
-    void givenArticleCommentInfo_whenUpdatingArticleComment_thenUpdatesArticleComment() {
-        // Given
-        String oldContent = "content";
-        String updatedContent = "댓글";
-        ArticleComment articleComment = createArticleComment(oldContent);
-        ArticleCommentDto dto = createArticleCommentDto(updatedContent);
-        given(articleCommentRepository.getReferenceById(dto.id())).willReturn(articleComment);
-
-        // When
-        sut.updateArticleComment(dto);
-
-        // Then
-        assertThat(articleComment.getContent())
-                .isNotEqualTo(oldContent)
-                .isEqualTo(updatedContent);
-        then(articleCommentRepository).should().getReferenceById(dto.id());
-    }
-
-    @DisplayName("없는 댓글 정보를 수정하려고 하면, 경고 로그를 찍고 아무 것도 안 한다.")
-    @Test
-    void givenNonexistentArticleComment_whenUpdatingArticleComment_thenLogsWarningAndDoesNothing() {
-        // Given
-        ArticleCommentDto dto = createArticleCommentDto("댓글");
-        given(articleCommentRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
-
-        // When
-        sut.updateArticleComment(dto);
-
-        // Then
-        then(articleCommentRepository).should().getReferenceById(dto.id());
-    }
-
     @DisplayName("댓글 ID를 입력하면, 댓글을 삭제한다.")
     @Test
     void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {


### PR DESCRIPTION
댓글 업데이트 기능의 삭제 pr
만들어만 두고 프로젝트 기획상 사용하지 않던 기능이었다.

This closes #95 